### PR TITLE
Remove 'foot_traffic' key as this tag is highly problematic; fix #2

### DIFF
--- a/src/components/RackDetail.svelte
+++ b/src/components/RackDetail.svelte
@@ -62,7 +62,6 @@
     "bicycle_parking",
     "capacity",
     "covered",
-    "foot_traffic",
     "access",
     "indoor",
     "description",
@@ -268,16 +267,6 @@
             <P size="sm" weight="medium">
               {$t(tags.indoor === "yes" ? "common.yes" : "common.no")}
             </P>
-          </div>
-        </ListgroupItem>
-      {/if}
-      {#if tags.foot_traffic}
-        <ListgroupItem>
-          <div class="flex flex-col">
-            <P size="sm">{$t("rack.attributes.foot_traffic")}</P>
-            <P size="sm" weight="medium"
-              >{$t(`rack.foot_traffic.${tags.foot_traffic}`)}</P
-            >
           </div>
         </ListgroupItem>
       {/if}

--- a/src/components/RackForm.svelte
+++ b/src/components/RackForm.svelte
@@ -200,32 +200,6 @@
       name: $t("rack.covered.partial"),
     },
   ];
-  const footTrafficOptions = [
-    {
-      value: "high",
-      name: `${$t("rack.foot_traffic.high")} (${$t(
-        "rack.foot_traffic.highDescription"
-      )})`,
-    },
-    {
-      value: "medium",
-      name: `${$t("rack.foot_traffic.medium")} (${$t(
-        "rack.foot_traffic.mediumDescription"
-      )})`,
-    },
-    {
-      value: "low",
-      name: `${$t("rack.foot_traffic.low")} (${$t(
-        "rack.foot_traffic.lowDescription"
-      )})`,
-    },
-    {
-      value: "none",
-      name: `${$t("rack.foot_traffic.none")} (${$t(
-        "rack.foot_traffic.noneDescription"
-      )})`,
-    },
-  ];
 
   async function submit() {
     const mapCenter = get(mapStore).center;
@@ -389,16 +363,6 @@
       bind:value={form.covered}
       id="covered"
       items={coverageOptions}
-      placeholder={$t("common.chooseOption")}
-    />
-  </Label>
-
-  <Label for="foot_traffic">
-    <div class="mb-1">{$t("rack.attributes.foot_traffic")}</div>
-    <Select
-      bind:value={form.foot_traffic}
-      id="foot_traffic"
-      items={footTrafficOptions}
       placeholder={$t("common.chooseOption")}
     />
   </Label>

--- a/src/components/RacksList.svelte
+++ b/src/components/RacksList.svelte
@@ -5,7 +5,6 @@
   import {
     type RackCoverage,
     type RackAccess,
-    type RackFootTraffic,
     type RackType,
   } from "../types/rack";
   import RackIcon from "../lib/icons/RackIcon.svelte";
@@ -31,11 +30,6 @@
     return $t(`rack.covered.${coverage}`);
   }
 
-  function renderFootTraffic(footTraffic: RackFootTraffic) {
-    if (!footTraffic) return null;
-    return $t(`rack.foot_traffic.${footTraffic}`);
-  }
-
   function renderAccess(access: RackAccess) {
     if (!access || access === "yes") return null;
     return $t(`rack.access.${access}`);
@@ -51,10 +45,9 @@
   function renderDetails(tags) {
     const indoor = renderIndoor(tags.indoor);
     const coverage = renderCoverage(tags.covered);
-    const footTraffic = renderFootTraffic(tags.foot_traffic);
     const access = renderAccess(tags.access);
     const capacity = renderCapacity(tags.capacity);
-    return [indoor, coverage, footTraffic, access, capacity]
+    return [indoor, coverage, access, capacity]
       .filter(Boolean)
       .join(" • ");
   }

--- a/src/components/SearchOptionsModal.svelte
+++ b/src/components/SearchOptionsModal.svelte
@@ -43,12 +43,6 @@
       // TODO: Fallback to friendlyName/snakeToWords
       name: $t(`rack.type.${type}`),
     })),
-    footTraffic: [
-      { value: "high", name: $t("rack.foot_traffic.high") },
-      { value: "medium", name: $t("rack.foot_traffic.medium") },
-      { value: "low", name: $t("rack.foot_traffic.low") },
-      { value: "none", name: $t("rack.foot_traffic.none") },
-    ],
     covered: [
       { value: "yes", name: $t("rack.covered.yes") },
       { value: "partial", name: $t("rack.covered.partial") },
@@ -96,14 +90,6 @@
     bind:value={filter.ignoreType}
     id="covered"
     items={filterOptions.type}
-    class="!mt-2"
-  />
-
-  <Label for="covered">{$t("rack.attributes.foot_traffic")}</Label>
-  <MultiSelect
-    bind:value={filter.footTraffic}
-    id="covered"
-    items={filterOptions.footTraffic}
     class="!mt-2"
   />
 

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -65,7 +65,6 @@ export default {
         distance: "Entfernung",
         access: "Zugang",
         covered: "Überdachung",
-        foot_traffic: "Fußgängerverkehr",
         indoor: "Innenbereich",
         description: "Beschreibung",
       },
@@ -109,17 +108,6 @@ export default {
         yes: "Überdacht",
         partial: "Teilweise überdacht",
         no: "Nicht überdacht",
-      },
-      foot_traffic: {
-        none: "Kein Fußgängerverkehr",
-        noneDescription: "Hinter dem Gebäude, Gasse etc.",
-        low: "Wenig Fußgängerverkehr",
-        lowDescription: "Seitlich am Gebäude, Parkplatz etc.",
-        medium: "Mittlerer Fußgängerverkehr",
-        mediumDescription:
-          "Nahe einer belebten Gegend, aber nicht direkt sichtbar",
-        high: "Starker Fußgängerverkehr",
-        highDescription: "Öffentlicher Platz, Fußgängerweg etc.",
       },
       access: {
         private: "Privat",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -66,7 +66,6 @@ export default {
         distance: "Distance",
         access: "Access",
         covered: "Rain coverage",
-        foot_traffic: "Foot traffic",
         indoor: "Indoors",
         description: "Description",
       },
@@ -110,17 +109,6 @@ export default {
         yes: "Covered",
         partial: "Partially covered",
         no: "Exposed",
-      },
-      foot_traffic: {
-        none: "No foot traffic",
-        noneDescription: "Back of building, alleyway, etc",
-        low: "Low foot traffic",
-        lowDescription: "Side of building, parking lot, etc",
-        medium: "Medium foot traffic",
-        mediumDescription:
-          "Nearby a high traffic area, but not directly visible",
-        high: "High foot traffic",
-        highDescription: "Public square, ped path, etc",
       },
       access: {
         private: "Private",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -66,7 +66,6 @@ export default {
         distance: "Distancia",
         access: "Acceso",
         covered: "Cobertura de lluvia",
-        foot_traffic: "Tráfico de peatones",
         indoor: "En interiores",
         description: "Descripción",
       },
@@ -110,17 +109,6 @@ export default {
         yes: "Cubierto",
         partial: "Parcialmente cubierto",
         no: "Expuesto",
-      },
-      foot_traffic: {
-        none: "Sin tráfico peatonal",
-        noneDescription: "Parte trasera del edificio, callejón, etc.",
-        low: "Tráfico peatonal bajo",
-        lowDescription: "Lado del edificio, estacionamiento, etc.",
-        medium: "Tráfico peatonal medio",
-        mediumDescription:
-          "Cerca de un área de alto tráfico, pero no directamente visible",
-        high: "Tráfico peatonal alto",
-        highDescription: "Plaza pública, camino peatonal, etc.",
       },
       access: {
         private: "Privado",

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -66,7 +66,6 @@ export default {
         distance: "Distance",
         acces: "Accès",
         covered: "Couverture de pluie",
-        foot_traffic: "Trafic piétonnier",
         indoor: "À l'intérieur",
         description: "Description",
       },
@@ -110,17 +109,6 @@ export default {
         yes: "Couvert",
         partial: "Partiellement couvert",
         no: "Exposé",
-      },
-      foot_traffic: {
-        none: "Aucun trafic piétonnier",
-        noneDescription: "Arrière du bâtiment, ruelle, etc.",
-        low: "Faible trafic piétonnier",
-        lowDescription: "Côté du bâtiment, parking, etc.",
-        medium: "Trafic piétonnier moyen",
-        mediumDescription:
-          "Près d'une zone à fort trafic, mais pas directement visible",
-        high: "Trafic piétonnier élevé",
-        highDescription: "Place publique, chemin piétonnier, etc.",
       },
       access: {
         private: "Privé",

--- a/src/store/racks.ts
+++ b/src/store/racks.ts
@@ -4,7 +4,6 @@ import {
   type Rack,
   type RackCoverage,
   type RackType,
-  type RackFootTraffic,
 } from "../types/rack";
 import { mapStore } from "./map";
 import { prefsStore } from "./prefs";
@@ -17,7 +16,6 @@ export type SortOptions = {
 export type FilterOptions = {
   ignoreType: RackType[];
   covered: RackCoverage[];
-  footTraffic: RackFootTraffic[];
   indoorOnly: boolean;
   minCapacity: number;
   maxDistance: number;
@@ -43,7 +41,6 @@ const searchOptionsStore = syncedWritable<{
   filter: {
     ignoreType: [],
     covered: [],
-    footTraffic: [],
     indoorOnly: false,
     minCapacity: 1,
     maxDistance: 1000,
@@ -114,7 +111,6 @@ const racks = derived(
         const {
           ignoreType,
           covered: coveredSelection,
-          footTraffic: trafficSelection,
           indoorOnly,
           minCapacity,
           maxDistance,
@@ -125,19 +121,11 @@ const racks = derived(
         const {
           bicycle_parking: type,
           covered,
-          foot_traffic,
           indoor,
         } = rack.tags;
 
         // Hide types
         if (ignoreType && ignoreType?.length && ignoreType.includes(type)) {
-          return false;
-        }
-        // Foot traffic
-        if (
-          (!foot_traffic && trafficSelection?.length) ||
-          (trafficSelection?.length && !trafficSelection.includes(foot_traffic))
-        ) {
           return false;
         }
         // Rain coverage

--- a/src/types/rack.ts
+++ b/src/types/rack.ts
@@ -32,7 +32,6 @@ export const RackCoverages = ["yes", "no", "partial"] as const;
 export type RackType = (typeof RackTypes)[number];
 export type RackCoverage = (typeof RackCoverages)[number];
 export type RackAccess = "yes" | "private" | "permissive";
-export type RackFootTraffic = "high" | "medium" | "low" | "none";
 export type RackIndoor = "yes" | "no";
 
 // https://wiki.openstreetmap.org/wiki/Key:bicycle_parking
@@ -42,7 +41,6 @@ export type RackTags = {
   capacity?: number;
   covered?: RackCoverage;
   access?: RackAccess;
-  foot_traffic?: RackFootTraffic;
   indoor?: RackIndoor;
   description?: string;
 };


### PR DESCRIPTION
Hey Alex,

After raising the issue again on the community forum, I still think that the `foot_traffic`-tag is highly problematic, especially in the current form that rack finder uses.

As I found a bit of time tonight, I took the liberty to strip out the related parts out of rackfinder.

Kind regards