### PR TITLE
Add a noscript message

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,10 @@
 </head>
 
 <body>
+  <noscript>
+    rackfinder.app requires JavaScript to be enabled. Website source code is available at
+    <a href="https://github.com/alexwohlbruck/rack-finder">https://github.com/alexwohlbruck/rack-finder</a>
+  </noscript>
   <div id="app"></div>
   <script type="module" src="/src/main.js"></script>
   <script>


### PR DESCRIPTION
Some users (myself included) leave JavaScript disabled by default. Sometimes that makes it difficult to tell whether a website is slow/broken or if it needs JavaScript to be enabled to show anything at all. This change makes the site show a message when scripting is disabled.

Your project doesn't seem to have a license (#11!), so in order to make it legal[^1] for you to incorporate this patch, I hereby release this contribution to the public domain.

Thanks!

[^1]: (Please note that I am not a lawyer and this does not constitute legal advice)